### PR TITLE
Simplify Windows installation using the official CSFML distribution

### DIFF
--- a/SFML.cabal
+++ b/SFML.cabal
@@ -15,7 +15,6 @@ cabal-version:       >=1.8
 
 Flag OfficialCSFMLForWindows
   Description: Use the official CSFML bundle for Windows from http://www.sfml-dev.org/download/csfml/
-  --Default:     False
 
 
 library


### PR DESCRIPTION
This pull request enables Windows users to install SFML via cabal without neither VisualStudio nor CMake.

Windows users will just need to download SFML and CSFML for windows (from http://www.sfml-dev.org/download/sfml/2.1/ and http://www.sfml-dev.org/download/csfml/ respectively) and invoke cabal install with proper options (--enable-lib-dirs and --enable-include-dirs).
