### PR TITLE
Fix demos' build by adding a dumb LICENSE file.

### DIFF
--- a/demos/LICENSE
+++ b/demos/LICENSE
@@ -1,0 +1,1 @@
+All Right Reserved 

--- a/demos/demos.cabal
+++ b/demos/demos.cabal
@@ -3,7 +3,7 @@ version: 0.1.0.0
 cabal-version: >=1.8
 build-type: Simple
 license: AllRightsReserved
-license-file: ""
+license-file: "LICENSE"
 synopsis: SFML demos
 category: Game
 author: Marc Sunet


### PR DESCRIPTION
The upstream's demos.cabal contains an empty **license-file** directive that breaks **cabal install**.
