### PR TITLE
add support for touch events

### DIFF
--- a/demos/fingerpaint/main.hs
+++ b/demos/fingerpaint/main.hs
@@ -1,0 +1,58 @@
+import SFML.Graphics
+import SFML.Window
+
+
+colors :: [Color]
+colors = [red, blue, green, magenta, cyan, yellow]
+
+nColors :: Int
+nColors = length colors
+
+
+main = do
+  vMode <- getDesktopMode
+  wnd <- createRenderWindow vMode "SFML Haskell Demo" [SFFullscreen] Nothing
+  va <- createVA
+  setPrimitiveType va Triangles
+  loop wnd va
+  destroy va
+  destroy wnd
+
+
+loop :: RenderWindow -> VertexArray -> IO ()
+loop wnd va = do
+  ret <- processEvt wnd va
+  case ret of
+    False -> return ()
+    True -> do
+      clearRenderWindow wnd black
+      drawVertexArray wnd va Nothing
+      display wnd
+      loop wnd va
+
+
+appendVertex :: VertexArray -> Int -> Int -> Int -> IO ()
+appendVertex va f x y = do
+  let color = colors !! (f `mod` nColors)
+      x1 = fromIntegral $ x - 10
+      x2 = fromIntegral $ x + 10
+      y1 = fromIntegral $ y - 10
+      y2 = fromIntegral $ y + 10
+      corners = [ Vec2f x1 y1, Vec2f x1 y2, Vec2f x2 y2,
+                  Vec2f x1 y1, Vec2f x2 y2, Vec2f x2 y1 ]
+      vtx v = Vertex v color v
+      vertices = map vtx corners
+  mapM_ (appendVA va) vertices
+
+
+processEvt :: RenderWindow -> VertexArray -> IO Bool
+processEvt wnd va = do
+  evt <- pollEvent wnd
+  case evt of
+    Just SFEvtClosed -> return False
+    Just (SFEvtKeyPressed {code = KeyEscape}) -> return False
+    Just (SFEvtTouchBegan f x y) -> appendVertex va f x y >> processEvt wnd va
+    Just (SFEvtTouchMoved f x y) -> appendVertex va f x y >> processEvt wnd va
+    Just (SFEvtTouchEnded f x y) -> appendVertex va f x y >> processEvt wnd va
+    Nothing -> return True
+    _ -> processEvt wnd va

--- a/demos/sfml-demos.cabal
+++ b/demos/sfml-demos.cabal
@@ -55,3 +55,9 @@ executable sfml-unicode
     buildable:          True
     ghc-options:        -debug
 
+executable sfml-fingerpaint
+    hs-source-dirs:     fingerpaint
+    build-depends:      base, SFML
+    main-is:            main.hs
+    buildable:          True
+    ghc-options:        -debug

--- a/src/SFML/Window/Event.hsc
+++ b/src/SFML/Window/Event.hsc
@@ -91,6 +91,21 @@ data SFEvent
     | SFEvtJoystickDisconnected
     { joystickId :: Int
     }
+    | SFEvtTouchBegan
+    { finger :: Int
+    , x      :: Int
+    , y      :: Int
+    }
+    | SFEvtTouchMoved
+    { finger :: Int
+    , x      :: Int
+    , y      :: Int
+    }
+    | SFEvtTouchEnded
+    { finger :: Int
+    , x      :: Int
+    , y      :: Int
+    }
     deriving (Eq, Show)
 
 
@@ -161,6 +176,18 @@ instance Storable SFEvent where
                    <*> fmap realToFrac (#{peek sfJoystickMoveEvent, position} ptr :: IO CFloat)
                 17 -> peekByteOff ptr sizeInt >>= return . SFEvtJoystickConnected
                 18 -> peekByteOff ptr sizeInt >>= return . SFEvtJoystickDisconnected
+                19 -> SFEvtTouchBegan
+                   <$> fmap fromIntegral (#{peek sfTouchEvent, finger} ptr :: IO CUInt)
+                   <*> fmap fromIntegral (#{peek sfTouchEvent, x} ptr :: IO CInt)
+                   <*> fmap fromIntegral (#{peek sfTouchEvent, y} ptr :: IO CInt)
+                20 -> SFEvtTouchMoved
+                   <$> fmap fromIntegral (#{peek sfTouchEvent, finger} ptr :: IO CUInt)
+                   <*> fmap fromIntegral (#{peek sfTouchEvent, x} ptr :: IO CInt)
+                   <*> fmap fromIntegral (#{peek sfTouchEvent, y} ptr :: IO CInt)
+                21 -> SFEvtTouchEnded
+                   <$> fmap fromIntegral (#{peek sfTouchEvent, finger} ptr :: IO CUInt)
+                   <*> fmap fromIntegral (#{peek sfTouchEvent, x} ptr :: IO CInt)
+                   <*> fmap fromIntegral (#{peek sfTouchEvent, y} ptr :: IO CInt)
 
     poke ptr evt = return ()
 


### PR DESCRIPTION
This adds support for SFML touch events in Haskell, and also adds a demo program to show the use of touch events.

I tested this using the [Raspberry Pi Touch Display](https://www.raspberrypi.org/products/raspberry-pi-touch-display/) in conjunction with [my pull request to sfml-pi](https://github.com/mickelson/sfml-pi/pull/5), but presumably this would also be relevant to other platforms that support SFML touch events (i. e. phones).
